### PR TITLE
Add support for customer specified tenant naming

### DIFF
--- a/kubernetes/cray-hnc-manager/Chart.yaml
+++ b/kubernetes/cray-hnc-manager/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-hnc-manager
-version: 0.0.2
+version: 0.0.3
 description: Hierarchical Namespace Controller (HNC) Manger
 keywords:
   - cray-hnc-manager

--- a/kubernetes/cray-hnc-manager/README.md
+++ b/kubernetes/cray-hnc-manager/README.md
@@ -18,10 +18,20 @@ Steps to update this chart:
 
    * In the templates dir:
 
-   ```
+     ```
      HNC_VERSION=v1.0.0-rc2
-   curl -o hnc-manager-${HNC_VERSION}.yaml https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/${HNC_VERSION}/default.yaml
-   ```
+     curl -o hnc-manager-${HNC_VERSION}.yaml https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/${HNC_VERSION}/default.yaml
+     ```
 
    * comment out the namespace creation at the top (cray-drydock does that)
+   * add back this section for the manager args so it honors customizations:
+
+     ```
+     {{- if .Values.validTenantNamePrefix }}
+     - --included-namespace-regex=(^tenants$|^{{ .Values.validTenantNamePrefix }}.*)
+     {{- else }}
+     - --included-namespace-regex=(^tenants$)
+     {{- end }}
+     ```
+
    * remove the old version (hnc-manager-v0.9.0.yaml)

--- a/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0-rc2.yaml
+++ b/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0-rc2.yaml
@@ -614,6 +614,11 @@ spec:
         - --excluded-namespace=kube-public
         - --excluded-namespace=hnc-system
         - --excluded-namespace=kube-node-lease
+        {{- if .Values.validTenantNamePrefix }}
+        - --included-namespace-regex=(^tenants$|^{{ .Values.validTenantNamePrefix }}.*)
+        {{- else }}
+        - --included-namespace-regex=(^tenants$)
+        {{- end }}
         - --enable-internal-cert-management
         - --cert-restart-on-secret-refresh
         command:

--- a/kubernetes/cray-hnc-manager/values.yaml
+++ b/kubernetes/cray-hnc-manager/values.yaml
@@ -33,7 +33,16 @@ image:
 
 #
 # Only apply hnc configuration to tenants namespace,
-# along with requiring namespaces managed by hnc have
-# 'tenant' in the name.
+# along with names that begin with a customer specified
+# prefix.
 #
-includedNamespacesRegex: tenant.*
+# For example, the following setting would allow hnc management
+# of the 'tenants' namespace (default), as well as vcluster.*
+# tenant names:
+#
+#   validTenantNamePrefix: vcluster
+#
+# Default behavior is to require 'tenant' as the tenant/namespace
+# prefix.
+#
+validTenantNamePrefix: tenant


### PR DESCRIPTION
## Summary and Scope

Allow customer to determine what naming convention is for customer created tenants.

## Issues and Related PRs

* Resolves [CASMINST-4516](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4516)

## Testing

```
tenants
└── [s] vcluster-coke
    ├── [s] vcluster-coke-slurm
    └── [s] vcluster-coke-user
```

### Tested on:

  * Virtual Shasta

### Test description:

Created tenant with and without valid name.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

