### PR TITLE
Add slurm/tapms namespaces for multi-tenancy isolation

### DIFF
--- a/kubernetes/cray-hnc-manager/Chart.yaml
+++ b/kubernetes/cray-hnc-manager/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-hnc-manager
-version: 0.0.3
+version: 0.0.1
 description: Hierarchical Namespace Controller (HNC) Manger
 keywords:
   - cray-hnc-manager

--- a/kubernetes/cray-hnc-manager/README.md
+++ b/kubernetes/cray-hnc-manager/README.md
@@ -27,10 +27,18 @@ Steps to update this chart:
    * add back this section for the manager args so it honors customizations:
 
      ```
+     timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}
+     ```
+
+     ```
+     replicas: {{ .Values.numReplicas }}
+     ```
+
+     ```
      {{- if .Values.validTenantNamePrefix }}
-     - --included-namespace-regex=(^tenants$|^{{ .Values.validTenantNamePrefix }}.*)
+     - --included-namespace-regex=(^multi-tenancy$|^tenants$|^tapms-operator$|^slurm-operator$|^{{ .Values.validTenantNamePrefix }}.*)
      {{- else }}
-     - --included-namespace-regex=(^tenants$)
+     - --included-namespace-regex=(^multi-tenancy$|^tenants$|^tapms-operator$|^slurm-operator$)
      {{- end }}
      ```
 

--- a/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0-rc2.yaml
+++ b/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0-rc2.yaml
@@ -593,7 +593,7 @@ metadata:
   name: hnc-controller-manager
   namespace: hnc-system
 spec:
-  replicas: 1
+  replicas: {{ .Values.numReplicas }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -615,9 +615,9 @@ spec:
         - --excluded-namespace=hnc-system
         - --excluded-namespace=kube-node-lease
         {{- if .Values.validTenantNamePrefix }}
-        - --included-namespace-regex=(^tenants$|^{{ .Values.validTenantNamePrefix }}.*)
+        - --included-namespace-regex=(^multi-tenancy$|^tenants$|^tapms-operator$|^slurm-operator$|^{{ .Values.validTenantNamePrefix }}.*)
         {{- else }}
-        - --included-namespace-regex=(^tenants$)
+        - --included-namespace-regex=(^multi-tenancy$|^tenants$|^tapms-operator$|^slurm-operator$)
         {{- end }}
         - --enable-internal-cert-management
         - --cert-restart-on-secret-refresh
@@ -768,7 +768,7 @@ webhooks:
     - '*'
     scope: Namespaced
   sideEffects: None
-  timeoutSeconds: 2
+  timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}
 - admissionReviewVersions:
   - v1
   clientConfig:

--- a/kubernetes/cray-hnc-manager/templates/rbac-jobs.yaml
+++ b/kubernetes/cray-hnc-manager/templates/rbac-jobs.yaml
@@ -1,0 +1,50 @@
+{{- /*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+# Job support
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-hnc-manager-jobs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-hnc-manager-jobs-role
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cray-hnc-manager-jobs-role-binding
+subjects:
+- kind: ServiceAccount
+  name: cray-hnc-manager-jobs
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-hnc-manager-jobs-role

--- a/kubernetes/cray-hnc-manager/templates/wait-jobs.yaml
+++ b/kubernetes/cray-hnc-manager/templates/wait-jobs.yaml
@@ -1,0 +1,59 @@
+{{- /*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+# 'wait' job that waits for hnc-controller-manager pods are up
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wait-for-hnc-manager-pods
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: wait-for-hnc-manager-pods
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: cray-hnc-manager-jobs
+      containers:
+        - name: wait
+          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - '/bin/sh'
+          args:
+            - '-c'
+            - kubectl rollout status deployment -n $MY_POD_NAMESPACE hnc-controller-manager
+          env:
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes/cray-hnc-manager/values.yaml
+++ b/kubernetes/cray-hnc-manager/values.yaml
@@ -37,12 +37,21 @@ image:
 # prefix.
 #
 # For example, the following setting would allow hnc management
-# of the 'tenants' namespace (default), as well as vcluster.*
+# of the 'tenants' namespace (default), as well as my-corp.*
 # tenant names:
 #
-#   validTenantNamePrefix: vcluster
+#   validTenantNamePrefix: my-corp
 #
-# Default behavior is to require 'tenant' as the tenant/namespace
+# Default behavior is to require 'vcluster' as the tenant/namespace
 # prefix.
 #
-validTenantNamePrefix: tenant
+validTenantNamePrefix: vcluster
+timeoutSeconds: 10
+numReplicas: 1
+
+# Needed for wait-for job
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

Refactor namespaces controlled by hnc controller, create specific namespaces for tapms and slurm.

## Issues and Related PRs

* Resolves [CASMINST-4841](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4841)
* Resolves [CASMINST-4843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4843)

## Testing

```
multi-tenancy
├── slurm-operator
├── tapms-operator
└── tenants
    ├── [s] vcluster-coke
    │   └── [s] vcluster-coke-user
    └── [s] vcluster-pepsi
        └── [s] vcluster-pepsi-user

[s] indicates subnamespaces
```

```
ncn-m001-48d9c509:/home/bklein # kubectl get secrets -n slurm-operator
NAME                  TYPE                                  DATA   AGE
default-token-vt5br   kubernetes.io/service-account-token   3      4m2s
wlm-s3-credentials    Opaque                                7      2m23s
```


### Tested on:

  * Virtual Shasta

### Test description:

Installed/uninstalled the following charts in concert:

```
   - name: cray-drydock
     version: 2.14.5
     namespace: loftsman
   - name: cray-vault
     version: 1.3.6
     namespace: vault
   - name: cray-psp
     version: 0.4.3
     namespace: services
   - name: cray-certmanager-issuers
     version: 0.6.5
     namespace: cert-manager
   - name: cray-hnc-manager
     version: 0.0.1
     namespace: hnc-system
   - name: cray-tapms-operator
     version: 0.0.1
     namespace: tapms-operator
   - name: cray-sample-subtenant-operator
     version: 0.0.1
     namespace: tenants
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
