### PR TITLE
Increase hnc webhook timeouts to avoid retries

### DIFF
--- a/kubernetes/cray-hnc-manager/Chart.yaml
+++ b/kubernetes/cray-hnc-manager/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-hnc-manager
-version: 0.0.3
+version: 0.0.4
 description: Hierarchical Namespace Controller (HNC) Manger
 keywords:
   - cray-hnc-manager

--- a/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0.yaml
+++ b/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0.yaml
@@ -699,6 +699,7 @@ webhooks:
     resources:
     - namespaces
   sideEffects: None
+  timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -725,6 +726,7 @@ webhooks:
     resources:
     - subnamespaceanchors
   sideEffects: None
+  timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -745,6 +747,7 @@ webhooks:
     resources:
     - hierarchyconfigurations
   sideEffects: None
+  timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -793,6 +796,7 @@ webhooks:
     resources:
     - hncconfigurations
   sideEffects: None
+  timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -814,3 +818,4 @@ webhooks:
     resources:
     - namespaces
   sideEffects: None
+  timeoutSeconds: {{ .Values.webhookTimeoutSeconds }}

--- a/kubernetes/cray-hnc-manager/values.yaml
+++ b/kubernetes/cray-hnc-manager/values.yaml
@@ -46,7 +46,7 @@ image:
 # prefix.
 #
 validTenantNamePrefix: vcluster
-timeoutSeconds: 10
+webhookTimeoutSeconds: 30
 numReplicas: 1
 
 # Needed for wait-for job


### PR DESCRIPTION
## Summary and Scope

Increase hnc webhook timeouts to avoid retries

## Issues and Related PRs

* Resolves [CASMINST-4897](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4897)

## Testing

```
ncn-m001-22703c05:/home/bklein # kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration -o yaml | grep timeout
  timeoutSeconds: 30
  timeoutSeconds: 30
  timeoutSeconds: 30
  timeoutSeconds: 30
  timeoutSeconds: 30
```

### Tested on:

  * Virtual Shasta

### Test description:

Updated the chart, saw the new timeouts, ran CRUD operations, no timeouts.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

