### PR TITLE
Ensure hnc webhook is responsive before completing chart deployment

### DIFF
--- a/kubernetes/cray-hnc-manager/Chart.yaml
+++ b/kubernetes/cray-hnc-manager/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-hnc-manager
-version: 0.0.4
+version: 0.0.5
 description: Hierarchical Namespace Controller (HNC) Manger
 keywords:
   - cray-hnc-manager

--- a/kubernetes/cray-hnc-manager/templates/wait-jobs.yaml
+++ b/kubernetes/cray-hnc-manager/templates/wait-jobs.yaml
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   template:
     metadata:
@@ -51,7 +51,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - kubectl rollout status deployment -n $MY_POD_NAMESPACE hnc-controller-manager
+            - 'while true; do echo "sleeping 10 seconds to ensure the deployment rollout has begun..."; sleep 10; kubectl rollout status deployment -n ${MY_POD_NAMESPACE} hnc-controller-manager; echo "sleeping 10 seconds allowing the webhook time to start..."; sleep 10; wget https://${HNC_WEBHOOK_SERVICE_SERVICE_HOST}:${HNC_WEBHOOK_SERVICE_SERVICE_PORT}/validate-v1-namespace?timeout=30s --post-data foo -S 2>&1 | grep -q SSL; if [ $? -eq 0 ]; then echo "Webhook is now responding..."; break; else echo "Webhook not responsive, sleeping 10 seconds..."; sleep 10; fi; done'
           env:
             - name: MY_POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
## Summary and Scope

In addition to making sure the hnc deployment is rolled out, also ensure the validating webhook is responsive.

## Issues and Related PRs

* Resolves [CASMPET-6098](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6098)

## Testing

```
kubectl logs -n hnc-system wait-for-hnc-manager-pods-8mkkf
sleeping 10 seconds to ensure the deployment rollout has begun...
Waiting for deployment "hnc-controller-manager" rollout to finish: 0 of 1 updated replicas are available...
deployment "hnc-controller-manager" successfully rolled out
sleeping 10 seconds allowing the webhook time to start...
Webhook is now responding...
```

### Tested on:

  * Virtual Shasta

### Test description:

Multiple chart installes

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

