### PR TITLE
CASMTRIAGE-7259: Update hnc-manager deployment to improve stability

### DIFF
--- a/kubernetes/cray-hnc-manager/Chart.yaml
+++ b/kubernetes/cray-hnc-manager/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-hnc-manager
-version: 0.1.0
+version: 0.1.1
 description: Hierarchical Namespace Controller (HNC) Manger
 keywords:
   - cray-hnc-manager

--- a/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0.yaml
+++ b/kubernetes/cray-hnc-manager/templates/hnc-manager-v1.0.0.yaml
@@ -627,7 +627,7 @@ spec:
         #image: gcr.io/k8s-staging-multitenancy/hnc-manager:v1.0.0
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         livenessProbe:
-          failureThreshold: 1
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8081

--- a/kubernetes/cray-hnc-manager/values.yaml
+++ b/kubernetes/cray-hnc-manager/values.yaml
@@ -47,7 +47,7 @@ image:
 #
 validTenantNamePrefix: vcluster
 webhookTimeoutSeconds: 30
-numReplicas: 2
+numReplicas: 1
 
 # Needed for wait-for job
 kubectl:


### PR DESCRIPTION
## Summary and Scope

Improves hnc-manager stability.  Previously this pod was showing hundreds or even thousands of restarts on every system, and in some cases this was interfering with tenant creation.

## Issues and Related PRs

* Resolves CASMTRIAGE-7259

## Testing

### Tested on:

  * Noname and Fanta

### Test description:

Verified the stability via the logs, and verified the ability to create multiple tenants.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

